### PR TITLE
Enable SPF record and full application of DMARC

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -19,7 +19,7 @@ resource "aws_route53_record" "route_53_root_txt" {
   type    = "TXT"
   ttl     = "300"
   records = [
-    #"v=spf1 include:amazonses.com include:_spf.google.com -all google-site-verification=9Hrl69xXhSeoBOVlnmpOYOSS6fYeiuGehZjHlyPZx3g"
+    "v=spf1 include:_spf.google.com include:amazonses.com ~all",
     "google-site-verification=9Hrl69xXhSeoBOVlnmpOYOSS6fYeiuGehZjHlyPZx3g"
   ]
 }

--- a/dns.tf
+++ b/dns.tf
@@ -52,7 +52,7 @@ resource "aws_route53_record" "route_53_dmarc_txt" {
   type    = "TXT"
   ttl     = "300"
   records = [
-    "v=DMARC1;p=quarantine;pct=75;rua=mailto:dmarc-rpt@seagl.org"
+    "v=DMARC1;p=quarantine;rua=mailto:dmarc-rpt@seagl.org"
   ]
 }
 


### PR DESCRIPTION
SPF:

 - Authorize Gmail and Amazon SES
 - Prioritize Gmail over Amazon SES; in the event that we inadvertently exceed the lookup limit, prioritize delivery of user mail over transactional mail
 - Request soft failure instead of hard failure

DMARC:

- Apply the policy to 100% of mail