### PR TITLE
Remove Amazon SES legacy TXT record

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -2,15 +2,6 @@ resource "aws_ses_domain_identity" "seagl" {
   domain = "seagl.org"
 }
 
-resource "aws_route53_record" "seagl_amazonses_verification_record" {
-  # this Zone needs to be imported still
-  zone_id = "Z0173878287JIU5M4KB8R"
-  name    = "_amazonses.seagl.org"
-  type    = "TXT"
-  ttl     = "600"
-  records = [aws_ses_domain_identity.seagl.verification_token]
-}
-
 # SPF
 resource "aws_route53_record" "route_53_root_txt" {
   # this Zone needs to be imported still


### PR DESCRIPTION
Amazon SES currently displays this notification:

> **Legacy TXT records**
>
> Domain verification in Amazon SES is now based on DomainKeys Identified Mail (DKIM), an email authentication standard that receiving mail servers use to validate an email’s authenticity. Configuring DKIM in your domain’s DNS settings confirms to SES that you’re the identity owner, eliminating the need for TXT records.