### PR TITLE
Make the Dokku host name a FQDN

### DIFF
--- a/dokku.tf
+++ b/dokku.tf
@@ -8,6 +8,6 @@ resource "aws_instance" "dokku" {
   vpc_security_group_ids = ["sg-0e719b49f7d4d7f08"]
 
   tags = {
-    Name = "dokku"
+    Name = "dokku.seagl.org"
   }
 }


### PR DESCRIPTION
This was required to get Ansible in GitHub Actions working without `~/.ssh/config` intervention.