### PR TITLE
Fix Mailu instance always getting rebuilt

### DIFF
--- a/mailu.tf
+++ b/mailu.tf
@@ -16,6 +16,6 @@ resource "openstack_compute_instance_v2" "mailu" {
 
   network {
     name        = "general_servers2"
-    fixed_ip_v4 = "140.211.167.146" # TODO can we/should we import this...?
+#    fixed_ip_v4 = "140.211.167.183" # TODO can we/should we import this...?
   }
 }


### PR DESCRIPTION
This is due to a problem on OSUOSL's side.