### PR TITLE
Add 2023 ephemeral homeserver DNS entries

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -189,3 +189,29 @@ resource "aws_route53_record" "mailu-test-dmarc" {
     "v=DMARC1; p=reject; rua=mailto:dmarc@mail-test.seagl.org; ruf=mailto:dmarc@mail-test.seagl.org; adkim=s; aspf=s"
   ]
 }
+
+# 2023 ephemeral Matrix homeserver
+
+locals {
+  matrix_2023_server_ip = "140.211.167.238"
+}
+
+resource "aws_route53_record" "matrix-2023-ephemeral-a" {
+  zone_id = "Z0173878287JIU5M4KB8R"
+  name    = "matrix.2023.seagl.org"
+  type    = "A"
+  ttl     = "300"
+  records = [
+    local.matrix_2023_server_ip
+  ]
+}
+
+resource "aws_route53_record" "matrix-2023-ephemeral-delegation-a" {
+  zone_id = "Z0173878287JIU5M4KB8R"
+  name    = "2023.seagl.org"
+  type    = "A"
+  ttl     = "300"
+  records = [
+    local.matrix_2023_server_ip
+  ]
+}

--- a/osem_rds/main.tf
+++ b/osem_rds/main.tf
@@ -28,7 +28,7 @@ resource "aws_db_instance" "osem" {
   allocated_storage       = 30
   max_allocated_storage   = 100
   engine                  = "mariadb"
-  engine_version          = "10.6.10"
+  engine_version          = "10.6.14"
   instance_class          = "db.t4g.micro"
   name                    = "osem"
   username                = "osem"


### PR DESCRIPTION
This assumes that:

* We're using `.well-known` delegation, with the web server at `2023.seagl.org` configured by the Synapse Ansible setup playbook
* We've disabled the automatic setup of Element, since people will be using the customized attend portal
* No other additional services are enabled

https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/configuring-dns.md