### PR TITLE
Bump RDS engine version

### DIFF
--- a/osem_rds/main.tf
+++ b/osem_rds/main.tf
@@ -28,7 +28,7 @@ resource "aws_db_instance" "osem" {
   allocated_storage       = 30
   max_allocated_storage   = 100
   engine                  = "mariadb"
-  engine_version          = "10.6.14"
+  engine_version          = "10.6.16"
   instance_class          = "db.t4g.micro"
   name                    = "osem"
   username                = "osem"


### PR DESCRIPTION
AWS automatically upgraded this and now it's dirtying `plan`.