### PR TITLE
Delete default Mailu SG rules

### DIFF
--- a/simple_vm/main.tf
+++ b/simple_vm/main.tf
@@ -1,5 +1,6 @@
 resource "openstack_networking_secgroup_v2" "main-sg" {
-  name = var.name
+  name                 = var.name
+  delete_default_rules = true
 }
 
 resource "openstack_networking_secgroup_rule_v2" "ipv4-egress" {


### PR DESCRIPTION
This is theoretically a noop because these default rules are already managed by Terraform, but the OpenStack provider insists on a destroy/ recreate cycle in order to introduce it.