### PR TITLE
Add A record for emails.

### DIFF
--- a/env/dns.tf
+++ b/env/dns.tf
@@ -149,3 +149,14 @@ resource "aws_route53_record" "mailu-test-dmarc" {
     "v=DMARC1; p=reject; rua=mailto:dmarc@mail-test.${var.zone_name}; ruf=mailto:dmarc@mail-test.${var.zone_name}; adkim=s; aspf=s"
   ]
 }
+
+resource "aws_route53_record" "Mailu server" {
+  zone_id = aws_route53_zone.apex.id
+  name    = "mail.${var.zone_name}"
+  type    = "A"
+  # TODO increase all these Mailu TTLs
+  ttl = "300"
+  records = [
+    "140.211.167.187"
+  ]
+}

--- a/env/dns.tf
+++ b/env/dns.tf
@@ -150,13 +150,12 @@ resource "aws_route53_record" "mailu-test-dmarc" {
   ]
 }
 
-resource "aws_route53_record" "Mailu server" {
+resource "aws_route53_record" "mailu-server" {
   zone_id = aws_route53_zone.apex.id
   name    = "mail.${var.zone_name}"
-  type    = "A"
-  # TODO increase all these Mailu TTLs
-  ttl = "300"
+  type    = "CNAME"
+  ttl     = "300"
   records = [
-    "140.211.167.187"
+    "mailu.host.${var.zone_name}"
   ]
 }


### PR DESCRIPTION
Per https://mailu.io/master/compose/setup.html#tls-certificates, Mailu needs the A record set for all HOSTNAMEs in the env file.
This sets mail.seagl.org to the mailu.host.seagl.org address, as is needed.