### PR TITLE
Configure Atlantis

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,0 +1,6 @@
+version: 3
+automerge: true
+delete_source_branch_on_merge: true
+projects:
+- name: my-project-name
+  dir: .


### PR DESCRIPTION
Mostly, this stops Atlantis from guessing that subdirectories are separate Terraform projects.