### PR TITLE
Update Dokku hostname

### DIFF
--- a/dokku.tf
+++ b/dokku.tf
@@ -8,6 +8,6 @@ resource "aws_instance" "dokku" {
   vpc_security_group_ids = ["sg-0e719b49f7d4d7f08"]
 
   tags = {
-    Name = "dokku.seagl.org"
+    Name = "dokku"
   }
 }


### PR DESCRIPTION
We're using this to align hostnames between Ansible dev and prod.

This change was already made ad-hoc in the console; this patch just aligns HCL.