### PR TITLE
Allow overriding simple_vm's user_data

### DIFF
--- a/simple_vm/main.tf
+++ b/simple_vm/main.tf
@@ -60,7 +60,7 @@ resource "openstack_compute_instance_v2" "instance" {
     ignore_changes = [user_data, block_device["uuid"], key_pair]
   }
 
-  user_data = <<-EOT
+  user_data = var.user_data != "" ? var.user_data : <<-EOT
     #cloud-config
     ssh_pwauth: false
     users:

--- a/simple_vm/variables.tf
+++ b/simple_vm/variables.tf
@@ -36,3 +36,9 @@ variable "dns_zone" {
     name    = string
   })
 }
+
+variable "user_data" {
+  description = "User data to attach to the VM. Consumed by cloud-init on many Linux distributions."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Useful for CoreOS, which takes Ignition config, not cloud-init config.