### PR TITLE
Switch production Dokku DNS to OSUOSL

### DIFF
--- a/env/dns.tf
+++ b/env/dns.tf
@@ -62,7 +62,7 @@ resource "aws_route53_record" "dokku_wildcard" {
   type    = "CNAME"
   ttl     = "300"
   records = [
-    "dokku.${var.zone_name}"
+    module.dokku-vm.hostname
   ]
 }
 


### PR DESCRIPTION
This change is already in production, this just fixes Terraform config drift.