### PR TITLE
Document Terraform, extract DNS vars, and add GitHub A/AAAA records

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,89 @@
+# SeaGL Cloud Infrastructure
+
+The bulf of SeaGL Cloud is graciously hosted at Oregon State University's Open Source Lab ([OSUOSL][osuosl]), with
+some peripheral components hosted elsewhere (for now). The [seagl.org][web] website is currently hosted
+on GitHub pages, pending a better alternative. DNS records for seagl.org are currently in AWS.
+
+The OSUOSL exposes [several services][osuosl-serv] to tenants, SeaGL makes use of the [OpenStack][openstack] endpoint.
+Resources across all three hosting locations are managed via [Terraform][terraform].
+
+# Contributing
+
+First, a cursory understanding of Terraform is required. Nothing more than an introductory tutorial is required.
+Terraform reads all the `*.tf` files in the root of the repository, along with any files referenced from them, to build
+a plan for how it will create/update/delete resources. Subdirectories define reusable modules and are only read when
+referenced. For example, the `simple_vm` module defines the basis for a virtual machine on OSUOSL's OpenStack. It is
+instantiated several times, once for each of the VMs in the SeaGL cloud.
+
+To bootstrap a development environment, install the Terraform CLI and the AWS CLI. To test DNS changes, a personal
+AWS account will be required (AWS is only used for DNS, which is a nearly zero cost service). To test VM changes,
+any compatible OpenStack cluster is required. Credentials for both will need to be made available in your shell
+environment for Terraform to use.
+
+```
+# OSUOSL OpenStack Credentials, or run `get-creds.sh` 
+export OS_USERNAME=
+export OS_PASSWORD=
+
+# AWS Credentials, or utilize AWS CLI profiles, AWS IAM Roles Anywhere, Identity Federation, etc
+export AWS_DEFAULT_REGION=
+export AWS_ACCESS_KEY_ID=
+export AWS_SECRET_ACCESS_KEY=
+export AWS_SESSION_TOKEN=
+# Confirm it is working
+aws sts get-caller-identity
+```
+
+Some resources are globally namespaced, such as AWS S3 buckets, so for personal development the names must
+be changed. The list of known resources to update are below (try to keep this up to date):
+
+| File path      | Provider  | Resource Type | Resource Id   | Production Value  |
+|----------------|-----------|---------------|---------------|-------------------|
+| `s3.tf`        | AWS       | S3 Bucket     | n/a           | `seagl-terraform` |
+| `terraform.tf` | Terraform | Backend       | n/a           | `seagl-terraform` |
+| `main.tf`      | Terraform | Variable      | zone_name     | `seagl.org`       |
+| `main.tf`      | Terraform | Variable      | github_domain | `seagl.github.io` |
+
+There's also a circular dependency which necessitates that the S3 bucket be created by hand:
+
+```
+aws s3api create-bucket \
+  --bucket seagl-terraform \
+  --create-bucket-configuration LocationConstraint=us-west-2
+```
+
+
+Then, run `terraform init` in the root directory to download Terraform extensions for OpenStack and AWS. To test a
+change to only one resource, use the `-target` parameter as show below to filter changes to just the resource(s)
+under development. For example, to see the outstanding changes to only the `attend.seagl.org` DNS record:
+
+```
+# Check reality against the configuration files, filtered to just DNS changes
+terraform plan \
+  -target aws_route53_record.attend-cname \
+  -out targeted.plan 
+# Rectify reality by following the planned changes
+terraform apply targeted.plan
+```
+
+To update the entire DNS infrastructure, multiple `-target` args can be assembled like this:
+
+```
+terraform plan 2>/dev/null \
+  | grep -Po '(?<= )[^ ]+(?= will be)' \
+  | grep route53 \
+  | sed -re "s/.+/-target '\\0' \\\\/"
+```
+
+**Integration with Test SeaGL Website**
+
+Follow the instructions in the [SeaGL website repo][web-repo] to fork a copy of the SeaGL
+website. Adjust the `github_domain` (and optionally `zone_name` if you have a spare domain
+lying around to test with) in `main.tf` to match your fork (and your test domain).
+
+[openstack]: https://www.openstack.org/
+[osuosl]: https://osuosl.org/
+[osuosl-serv]: https://osuosl.org/services/hosting/details/
+[terraform]: https://developer.hashicorp.com/terraform
+[web]: https://seagl.org
+[web-repo]: https://github.com/SeaGL/seagl.github.io#forkclone-the-repository

--- a/dns.tf
+++ b/dns.tf
@@ -1,6 +1,6 @@
 resource "aws_route53_record" "route_53_cloud_txt" {
   zone_id = module.production_env.zone_id
-  name    = "cloud.seagl.org"
+  name    = "cloud.${module.production_env.zone_name}"
   type    = "TXT"
   ttl     = "300"
   records = [
@@ -24,7 +24,7 @@ resource "aws_route53_record" "email_dkim_hubspot_records" {
 
 resource "aws_route53_record" "cloud-a" {
   zone_id = module.production_env.zone_id
-  name    = "cloud.seagl.org"
+  name    = "cloud.${module.production_env.zone_name}"
   type    = "A"
   ttl     = "300"
   records = [
@@ -34,7 +34,7 @@ resource "aws_route53_record" "cloud-a" {
 
 resource "aws_route53_record" "cloud-aaaa" {
   zone_id = module.production_env.zone_id
-  name    = "cloud.seagl.org"
+  name    = "cloud.${module.production_env.zone_name}"
   type    = "AAAA"
   ttl     = "300"
   records = [
@@ -44,7 +44,7 @@ resource "aws_route53_record" "cloud-aaaa" {
 
 resource "aws_route53_record" "bsky-verification-txt" {
   zone_id = module.production_env.zone_id
-  name    = "_atproto.seagl.org"
+  name    = "_atproto.${module.production_env.zone_name}"
   type    = "TXT"
   ttl     = "300"
   records = [
@@ -54,30 +54,30 @@ resource "aws_route53_record" "bsky-verification-txt" {
 
 resource "aws_route53_record" "birdhouse-cname" {
   zone_id = module.production_env.zone_id
-  name    = "birdhouse.seagl.org"
+  name    = "birdhouse.${module.production_env.zone_name}"
   type    = "CNAME"
   ttl     = "300"
   records = [
-    "seagl.github.io."
+    "${module.production_env.github_domain}."
   ]
 }
 
 resource "aws_route53_record" "attend-cname" {
   zone_id = module.production_env.zone_id
-  name    = "attend.seagl.org"
+  name    = "attend.${module.production_env.zone_name}"
   type    = "CNAME"
   ttl     = "300"
   records = [
-    "seagl.github.io."
+    "${module.production_env.github_domain}."
   ]
 }
 
 resource "aws_route53_record" "sponsor-cname" {
   zone_id = module.production_env.zone_id
-  name    = "sponsor.seagl.org"
+  name    = "sponsor.${module.production_env.zone_name}"
   type    = "CNAME"
   ttl     = "300"
   records = [
-    "seagl.github.io."
+    "${module.production_env.github_domain}."
   ]
 }

--- a/dns.tf
+++ b/dns.tf
@@ -1,3 +1,29 @@
+resource "aws_route53_record" "github_a_alias" {
+  zone_id = module.production_env.zone_id
+  name    = ""
+  type    = "A"
+  ttl     = 300
+  records = [
+    "185.199.108.153",
+    "185.199.109.153",
+    "185.199.110.153",
+    "185.199.111.153",
+  ]
+}
+
+resource "aws_route53_record" "github_aaaa_alias" {
+  zone_id = module.production_env.zone_id
+  name    = ""
+  type    = "AAAA"
+  ttl     = 300
+  records = [
+    "2606:50c0:8000::153",
+    "2606:50c0:8001::153",
+    "2606:50c0:8002::153",
+    "2606:50c0:8003::153"
+  ]
+}
+
 resource "aws_route53_record" "route_53_cloud_txt" {
   zone_id = module.production_env.zone_id
   name    = "cloud.${module.production_env.zone_name}"

--- a/env/outputs.tf
+++ b/env/outputs.tf
@@ -1,3 +1,11 @@
+output "zone_name" {
+  value = aws_route53_zone.apex.name
+}
+
 output "zone_id" {
   value = aws_route53_zone.apex.id
+}
+
+output "github_domain" {
+  value = var.github_domain
 }

--- a/env/variables.tf
+++ b/env/variables.tf
@@ -3,6 +3,11 @@ variable "zone_name" {
   type        = string
 }
 
+variable "github_domain" {
+  description = "FQDN of GitHub-hosted website"
+  type        = string
+}
+
 variable "attach_to_zone" {
   description = "Route 53 zone object to attach (via NS record) the environment's zone to"
   default     = null

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 module "production_env" {
   source    = "./env"
   zone_name = "seagl.org"
+  github_domain = "seagl.github.io"
   additional_root_txts = [
     "google-site-verification=9Hrl69xXhSeoBOVlnmpOYOSS6fYeiuGehZjHlyPZx3g"
   ]


### PR DESCRIPTION
This should resolve https://github.com/SeaGL/seagl.github.io/issues/495 - both the initial concern related to lack of IPv6 support and some of the underlying concerns about the tractability of getting bootstrapped on the repo. 

Currently, the requirements for actually testing changes in this repo are too high. They require a spare domain, an AWS account, and an OpenStack cluster. Some changes only require a subset of the above, but barely any changes require none of them. Although it is possible to test DNS-only changes with a $0.99 domain and a free-tier AWS account, both of those are intractable for individuals without access to a credit card. We should consider creating a parallel test stack and establishing a process by which interested contributors can test their changes on it -- either directly (by vending time-limited, tightly-scoped credentials) or indirectly (via pull request automation, or by getting staff to manifest the changes).

The A and AAAA records come from [GitHub documentation](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#dns-records-for-your-custom-domain). The `ALIAS` / `ANAME` record types are [only in draft status](https://en.wikipedia.org/wiki/List_of_DNS_record_types) so we should [watch the IETF RFC draft](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-aname-04) for changes (last updated: 2019).