### PR TITLE
Point `osem.seagl.org` at GitHub Pages

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -72,6 +72,16 @@ resource "aws_route53_record" "attend-cname" {
   ]
 }
 
+resource "aws_route53_record" "osem-cname" {
+  zone_id = module.production_env.zone_id
+  name    = "osem.seagl.org"
+  type    = "CNAME"
+  ttl     = "300"
+  records = [
+    "seagl.github.io."
+  ]
+}
+
 resource "aws_route53_record" "sponsor-cname" {
   zone_id = module.production_env.zone_id
   name    = "sponsor.seagl.org"

--- a/dns.tf
+++ b/dns.tf
@@ -74,7 +74,7 @@ resource "aws_route53_record" "attend-cname" {
 
 resource "aws_route53_record" "osem-cname" {
   zone_id = module.production_env.zone_id
-  name    = "osem.seagl.org"
+  name    = "osem-static.seagl.org" # TODO: Remove `-static` after review
   type    = "CNAME"
   ttl     = "300"
   records = [


### PR DESCRIPTION
Re https://vikunja.seagl.org/tasks/283, replace OSEM with [SeaGL/osem.seagl.org-static](https://github.com/SeaGL/osem.seagl.org-static) served via GitHub Pages.

This will effectively remove the ability to log in to OSEM to e.g. update user profiles or access the organizer interface.